### PR TITLE
Normally pass in the config_section name, and override the config …

### DIFF
--- a/packagepoa/transform.py
+++ b/packagepoa/transform.py
@@ -192,8 +192,8 @@ def move_new_zipfile(doi, poa_config):
     shutil.move(new_zipfile_name_plus_path, poa_config.get('output_dir') + "/" + new_zipfile_name)
 
 
-def process_zipfile(zipfile_name, poa_config, config_section=None):
-    # configuration
+def process_zipfile(zipfile_name, config_section=None, poa_config=None):
+    # configuration can be passed in or parsed from the config_section
     if not poa_config:
         poa_config = parse_raw_config(raw_config(config_section))
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -54,7 +54,8 @@ class TestTransform(unittest.TestCase):
         fake_decapitate = mock_decapitate_pdf('decap_elife_poa_e12717.pdf')
         zipfile_name = os.path.join(TEST_DATA_PATH,
                                     '18022_1_supp_mat_highwire_zip_268991_x75s4v.zip')
-        return_value = transform.process_zipfile(zipfile_name, POA_CONFIG)
+        # pass in the POA_CONFIG which has the testing directories modified
+        return_value = transform.process_zipfile(zipfile_name, None, POA_CONFIG)
         # check return value
         self.assertTrue(return_value)
         # check directory contents


### PR DESCRIPTION
…only when running tests.