### PR TITLE
Feature decap timeout

### DIFF
--- a/packagepoa/transform.py
+++ b/packagepoa/transform.py
@@ -13,6 +13,7 @@ import logging
 import shutil
 import os
 from xml.etree import ElementTree
+from func_timeout import func_timeout, FunctionTimedOut
 from packagepoa.decapitate_pdf import decapitate_pdf_with_error_check
 from packagepoa.conf import raw_config, parse_raw_config
 
@@ -31,6 +32,7 @@ formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
 hdlr.setFormatter(formatter)
 manifest_logger.addHandler(hdlr)
 manifest_logger.setLevel(logging.INFO)
+PDF_DECAPITATE_TIMEOUT = 120
 
 
 def article_id_from_doi(doi):
@@ -147,8 +149,18 @@ def copy_pdf_to_output_dir(file_title_map, output_dir, doi, current_zipfile, poa
             temp_file.write(file_from_zip)
             temp_file.close()
 
-    if decapitate_pdf_with_error_check(
-            decap_name_plus_path, poa_config.get('decapitate_pdf_dir') + os.sep, poa_config):
+    decap_status = None
+    try:
+        # pass the local file path, and the path to a temp dir, to the decapitation script
+        decap_status = func_timeout(
+            PDF_DECAPITATE_TIMEOUT, decapitate_pdf_with_error_check, args=(
+            decap_name_plus_path, poa_config.get('decapitate_pdf_dir') + os.sep, poa_config))
+    except FunctionTimedOut:
+        decap_status = False
+        timeout_message = "PDF decap did not finish within {x} seconds".format(x=PDF_DECAPITATE_TIMEOUT)
+        logger.error(timeout_message)
+    
+    if decap_status:
         # pass the local file path, and teh path to a temp dir, to the decapiation script
         try:
             file_content = None

--- a/packagepoa/transform.py
+++ b/packagepoa/transform.py
@@ -154,12 +154,12 @@ def copy_pdf_to_output_dir(file_title_map, output_dir, doi, current_zipfile, poa
         # pass the local file path, and the path to a temp dir, to the decapitation script
         decap_status = func_timeout(
             PDF_DECAPITATE_TIMEOUT, decapitate_pdf_with_error_check, args=(
-            decap_name_plus_path, poa_config.get('decapitate_pdf_dir') + os.sep, poa_config))
+                decap_name_plus_path, poa_config.get('decapitate_pdf_dir') + os.sep, poa_config))
     except FunctionTimedOut:
         decap_status = False
         timeout_message = "PDF decap did not finish within {x} seconds".format(x=PDF_DECAPITATE_TIMEOUT)
         logger.error(timeout_message)
-    
+
     if decap_status:
         # pass the local file path, and teh path to a temp dir, to the decapiation script
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 configparser==3.5.0
 mock==1.3.0
 coverage==4.4.2
+func_timeout==4.3.0

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -124,20 +124,17 @@ class TestTransform(unittest.TestCase):
     @patch.object(transform, 'decapitate_pdf_with_error_check')
     def test_copy_pdf_to_output_dir_timed_out_pdf(self, fake_decapitate):
         "tests of when pdf decapitaion reaches timeout"
-        # override the timeout value with 0 seconds to simulate a timeout
-        transform.PDF_DECAPITATE_TIMEOUT = -1
         zipfile_name = os.path.join(TEST_DATA_PATH,
                                     '18022_1_supp_mat_highwire_zip_268991_x75s4v.zip')
         file_title_map = {
             '18022_1_merged_1463214271.pdf': 'Merged PDF'
         }
+        fake_decapitate.side_effect = FunctionTimedOut
         doi = '10.7554/eLife.12717'
         with zipfile.ZipFile(zipfile_name, 'r') as current_zipfile:
             with self.assertRaises(Exception) as context:
                 return_value = transform.copy_pdf_to_output_dir(file_title_map, None, doi,
                                                                 current_zipfile, POA_CONFIG)
-        # set the timed out value back again
-        transform.PDF_DECAPITATE_TIMEOUT = 120
         clean_test_directories()
 
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -132,8 +132,8 @@ class TestTransform(unittest.TestCase):
             '18022_1_merged_1463214271.pdf': 'Merged PDF'
         }
         doi = '10.7554/eLife.12717'
-        with self.assertRaises(Exception) as context:
-            with zipfile.ZipFile(zipfile_name, 'r') as current_zipfile:
+        with zipfile.ZipFile(zipfile_name, 'r') as current_zipfile:
+            with self.assertRaises(Exception) as context:
                 return_value = transform.copy_pdf_to_output_dir(file_title_map, None, doi,
                                                                 current_zipfile, POA_CONFIG)
         # set the timed out value back again

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -132,11 +132,10 @@ class TestTransform(unittest.TestCase):
             '18022_1_merged_1463214271.pdf': 'Merged PDF'
         }
         doi = '10.7554/eLife.12717'
-        current_zipfile = zipfile.ZipFile(zipfile_name, 'r')
         with self.assertRaises(Exception) as context:
-            return_value = transform.copy_pdf_to_output_dir(file_title_map, None, doi,
-                                                            current_zipfile, POA_CONFIG)
-        current_zipfile.close()
+            with zipfile.ZipFile(zipfile_name, 'r') as current_zipfile:
+                return_value = transform.copy_pdf_to_output_dir(file_title_map, None, doi,
+                                                                current_zipfile, POA_CONFIG)
         # set the timed out value back again
         transform.PDF_DECAPITATE_TIMEOUT = 120
         clean_test_directories()

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -125,7 +125,7 @@ class TestTransform(unittest.TestCase):
     def test_copy_pdf_to_output_dir_timed_out_pdf(self, fake_decapitate):
         "tests of when pdf decapitaion reaches timeout"
         # override the timeout value with 0 seconds to simulate a timeout
-        transform.PDF_DECAPITATE_TIMEOUT = 0
+        transform.PDF_DECAPITATE_TIMEOUT = -1
         zipfile_name = os.path.join(TEST_DATA_PATH,
                                     '18022_1_supp_mat_highwire_zip_268991_x75s4v.zip')
         file_title_map = {


### PR DESCRIPTION
Basically duplicating the timeout feature of PR https://github.com/elifesciences/elife-poa-xml-generation/pull/317 into this more modern library (which is not in prod yet).

I tried to write a test for a timeout by setting the timeout to 0 seconds, which does end up testing one additional line of code, but it seems to raise an ``AttributeError`` instead of a ``FunctionTimedOut`` exception due to some mock object issues. I left in the new test since it does pass, although I didn't see a better way to simulate the timeout the way it is written right now.