### PR TITLE
Code linting

### DIFF
--- a/packagepoa/decapitate_pdf.py
+++ b/packagepoa/decapitate_pdf.py
@@ -4,15 +4,15 @@ import subprocess
 
 FORMAT = logging.Formatter("%(created)f - %(levelname)s - %(processName)s - %(name)s - %(message)s")
 LOGFILE = "decapitate_pdf.log"
+LOGGER = logging.getLogger(__file__)
+LOGGER.setLevel(logging.DEBUG)
+HDLR = logging.FileHandler(LOGFILE)
+HDLR.setLevel(logging.INFO)
+HDLR.setFormatter(FORMAT)
+LOGGER.addHandler(HDLR)
 
-logger = logging.getLogger(__file__)
-logger.setLevel(logging.DEBUG)
+PDF_EXECUTABLE_DEFAULT = "/opt/strip-coverletter/strip-coverletter-docker.sh"
 
-h = logging.FileHandler(LOGFILE)
-h.setLevel(logging.INFO)
-h.setFormatter(FORMAT)
-
-logger.addHandler(h)
 
 def decapitate_pdf_with_error_check(pdf_in, pdf_out_dir, poa_config=None):
     # configuration
@@ -25,31 +25,35 @@ def decapitate_pdf_with_error_check(pdf_in, pdf_out_dir, poa_config=None):
     # PDF out file name
     pdf_out = pdf_out_dir + pdf_in.split('/')[-1]
 
-    f = subprocess.Popen([pdf_executable, pdf_in, pdf_out], \
-                         stdout=subprocess.PIPE, \
-                         stderr=subprocess.PIPE)
+    process = subprocess.Popen(
+        [pdf_executable, pdf_in, pdf_out],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
 
-    stderr = f.stderr.read()
-    stdout = f.stdout.read()
+    stderr = process.stderr.read()
+    stdout = process.stdout.read()
 
     # subprocess.Popen doesn't interleave pipe output,
     # so neither will these log messages
-    map(logger.info, stdout.splitlines())
-    map(logger.error, stderr.splitlines())
+    map(LOGGER.info, stdout.splitlines())
+    map(LOGGER.error, stderr.splitlines())
 
-    return stderr != '' # no errors
+    return stderr != ''  # no errors
+
 
 if __name__ == '__main__':
     import sys
-    args = sys.argv[1:]
-    if len(args) < 2:
+    ARGS = sys.argv[1:]
+    if len(ARGS) < 2:
         print('Usage: decapitate_pdf.py <pdf-in> <pdf-out>')
         exit(1)
 
-    h2 = logging.StreamHandler()
-    h2.setLevel(logging.DEBUG)
-    h2.setFormatter(FORMAT)
-    logger.addHandler(h2)
+    HANDLER = logging.StreamHandler()
+    HANDLER.setLevel(logging.DEBUG)
+    HANDLER.setFormatter(FORMAT)
+    LOGGER.addHandler(HANDLER)
 
-    pin, pout = args[:2]
-    decapitate_pdf_with_error_check(pin, pout)
+    PIN = ARGS[0]
+    POUT = ARGS[1]
+    CONFIG = {'strip_coverletter_executable': PDF_EXECUTABLE_DEFAULT}
+    decapitate_pdf_with_error_check(PIN, POUT, CONFIG)

--- a/packagepoa/transform.py
+++ b/packagepoa/transform.py
@@ -108,7 +108,7 @@ def gen_new_zipfile(doi, poa_config):
 def move_files_into_new_zipfile(current_zipfile, file_title_map, new_zipfile, doi,
                                 poa_config):
     filename_pattern = poa_config.get('filename_pattern')
-    for name in file_title_map.keys():
+    for name in file_title_map:
         title = file_title_map[name]
         new_name = gen_new_name_for_file(name, title, doi, filename_pattern)
 
@@ -152,7 +152,7 @@ def pdf_details(file_title_map):
     "find the PDF file name in the zip file map"
     pdf_name = None
     title = None
-    for name in file_title_map.keys():
+    for name in file_title_map:
         file_title = file_title_map[name]
         if file_title == "Merged PDF":
             LOGGER.info("title: %s", title)
@@ -215,7 +215,7 @@ def copy_pdf_to_output_dir(file_title_map, output_dir, doi, current_zipfile, poa
 
 def remove_pdf_from_file_title_map(file_title_map):
     new_map = {}
-    for name in file_title_map.keys():
+    for name in file_title_map:
         title = file_title_map[name]
         if title == "Merged PDF":
             continue

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,18 @@
 from setuptools import setup
-
 import packagepoa
 
-with open('README.rst') as fp:
-    readme = fp.read()
 
-setup(name='packagepoa',
+with open('README.rst') as fp:
+    README = fp.read()
+
+
+setup(
+    name='packagepoa',
     version=packagepoa.__version__,
     description='Generate, transform and assemble files for a PoA article.',
-    long_description=readme,
+    long_description=README,
     packages=['packagepoa'],
-    license = 'MIT',
+    license='MIT',
     install_requires=[
         "configparser"
     ],

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -21,16 +21,19 @@ def mock_decapitate_pdf(filename):
     to_filename = os.path.join(POA_CONFIG.get('decapitate_pdf_dir'), filename)
     shutil.copy(from_filename, to_filename)
 
+
 def list_test_dir(dir_name, ignore=('.keepme')):
     "list the contents of a directory ignoring the ignore files"
     file_names = os.listdir(dir_name)
     return [file_name for file_name in file_names if file_name not in ignore]
+
 
 def clean_test_dir(dir_name, ignore=('.keepme')):
     "clean files from a test directory ignoring the .keepme file"
     file_names = list_test_dir(dir_name, ignore)
     for file_name in file_names:
         os.remove(os.path.join(dir_name, file_name))
+
 
 def clean_test_directories(ignore=('.keepme')):
     "clean each of the testing directories"
@@ -116,7 +119,6 @@ class TestTransform(unittest.TestCase):
         # for now it still returns True
         self.assertTrue(return_value)
 
-
     @patch.object(transform, 'decapitate_pdf_with_error_check')
     def test_copy_pdf_to_output_dir_timed_out_pdf(self, fake_decapitate):
         "tests of when pdf decapitaion reaches timeout"
@@ -128,10 +130,9 @@ class TestTransform(unittest.TestCase):
         fake_decapitate.side_effect = FunctionTimedOut
         doi = '10.7554/eLife.12717'
         with zipfile.ZipFile(zipfile_name, 'r') as current_zipfile:
-            with self.assertRaises(Exception) as context:
-                return_value = transform.copy_pdf_to_output_dir(file_title_map, None, doi,
-                                                                current_zipfile, POA_CONFIG)
-
+            with self.assertRaises(Exception):
+                transform.copy_pdf_to_output_dir(file_title_map, None, doi,
+                                                 current_zipfile, POA_CONFIG)
 
     def test_add_file_to_zipfile(self):
         "test adding files to a zip file"
@@ -142,6 +143,7 @@ class TestTransform(unittest.TestCase):
         with zipfile.ZipFile(zip_file_name, 'w') as zip_file:
             transform.add_file_to_zipfile(zip_file, file_name, None)
             self.assertEqual(zip_file.namelist(), [])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fairly straightforward changes in linting, variable names, whitespace, and some return values.

Refactoring of ``copy_pdf_to_output_dir()``, which invokes the magic of the PDF decapitation, results in smaller more discrete functions for each step.