### PR TITLE
Jenkins release downstream configuration.

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -12,6 +12,11 @@ elifePipeline {
         tag = elifePypiRelease()
         elifeGitTagRevision(tag)
     }
-    
+
+    stage 'Downstream', {
+        elifeMainlineOnly {
+            build job: '/dependencies/dependencies-elife-bot-update-dependency', parameters: [string(name: 'package', value: 'packagepoa'), string(name: 'tag', value: tag)], wait: false
+        }
+    }
 }
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6980

When there is a new release, start a pipeline to update the dependency in the `elife-bot` project.